### PR TITLE
chore: update GitHub Actions and Python versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,22 +4,19 @@ on: [pull_request]
 jobs:
   tests:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          python-version: |
-            3.10
-            3.11
-            3.12
-      - name: Set up pip cache
-        if: runner.os == 'Linux'
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('pyproject.toml') }}
-          restore-keys: ${{ runner.os }}-pip-
+          python-version: ${{ matrix.python-version }}
+
       - name: Install Hatch
         run: pipx install hatch
+
       - name: Run tests
         run: hatch test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,3 +81,6 @@ exclude_lines = [
 
 [tool.hatch.build.targets.sdist]
 only-include = ["src/markitdown"]
+
+[[tool.hatch.envs.test.matrix]]
+python = ["3.13", "3.12", "3.11", "3.10"]


### PR DESCRIPTION
Update the GitHub Actions checkout and setup-python 
versions to v4 and v5 respectively. Add Python 3.13 
to the testing matrix in both the workflow and 
pyproject.toml to ensure compatibility with the latest 
Python release.